### PR TITLE
Remove deprecated encoding from desktop file

### DIFF
--- a/volctl.desktop
+++ b/volctl.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Type=Application
 Name=Volctl
 Comment=Per-application volume control for GNU/Linux desktops


### PR DESCRIPTION
Lintian complaints about the encoding. Just remove it.

I: volctl: desktop-entry-contains-encoding-key usr/share/applications/volctl.desktop:2 Encoding
N: 
N:    The Encoding key is now deprecated by the FreeDesktop standard and all
N:    strings are required to be encoded in UTF-8. This desktop entry
N:    explicitly specifies an Encoding of UTF-8, which is harmless but no
N:    longer necessary.
N:    
N:    The desktop-file-validate tool in the desktop-file-utils package is
N:    useful for checking the syntax of desktop entries.
N:    
N:    Refer to
N:    https://specifications.freedesktop.org/desktop-entry-spec/1.0/apc.html
N:    for details.
N:    
N:    Severity: wishlist, Certainty: certain
N:    
N:    Check: menu-format, Type: binary