### PR TITLE
Initial support for Ubuntu app indicators

### DIFF
--- a/volctl/__init__.py
+++ b/volctl/__init__.py
@@ -1,8 +1,12 @@
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject
+gi.require_version('AppIndicator3', '0.1')
+from gi.repository import Gtk, GObject, AppIndicator3
 
 from tray import VolCtlTray
+import signal
+ 
+APPINDICATOR_ID = 'VolCtl'
 
 
 PROGRAM_NAME = 'Volume Control'
@@ -15,4 +19,11 @@ WEBSITE =      'https://buzz.github.io/volctl/'
 def main():
     GObject.threads_init()
     vctray = VolCtlTray()
+
+    indicator = AppIndicator3.Indicator.new(APPINDICATOR_ID, 'preferences-desktop', AppIndicator3.IndicatorCategory.SYSTEM_SERVICES)
+    indicator.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
+    indicator.set_menu(vctray.menu)
+
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
     Gtk.main()


### PR DESCRIPTION
In Ubuntu 16.04 there is no whitelist for the panel any longer.

So every application has to use the app indicator support.
Initial support to see the menu at least.
Problem is that there is no distinction between left
and right click. So the mixer is not shown.

Currently this is how the app looks with app indicator:
![volctl with app indicator]
(http://pix.toile-libre.org/upload/original/1461368359.png)

The is no difference between left and right click so you
can not see the mixer.
This has to be done like the sound control in Ubuntu:
![Ubuntus sound control]
(http://pix.toile-libre.org/upload/original/1461368378.png)

Personally I have no idea how to implement this.