### PR TITLE
Fixed window positioning when multiple monitors are connected

### DIFF
--- a/volctl/slider.py
+++ b/volctl/slider.py
@@ -48,12 +48,16 @@ class VolumeSlider:
     def set_position(self):
         a, screen, rect, orient = self.volctl.statusicon.get_geometry()
         win_width, win_height = self.win.get_size()
+        monitor = screen.get_monitor_geometry(
+            screen.get_monitor_at_window(screen.get_active_window()))
+        
         # slider window should not leave screen boundaries
         x = rect.x
-        if x + win_width > screen.width():
-            x = screen.width() - win_width
+        if x + win_width > monitor.width:
+            x = monitor.width - win_width
+            self.win.move(x, rect.y)
         # top or bottom panel?
-        if rect.y > screen.height() / 2:
+        if rect.y > monitor.height / 2:
             self.win.move(x, rect.y - win_height)
         else:
             self.win.move(x, rect.y + rect.height)


### PR DESCRIPTION
I noticed that the window positioning logic does not properly handle the presence of multiple monitors. By acquiring the dimensions of the monitor on which the `volctl` tray is meant to be displayed instead of treating all monitors like a continuous area I was able to correct this fault.

With kind regards,
Philip Trauner