### PR TITLE
Do not hard code pavucontrol path

### DIFF
--- a/volctl/app.py
+++ b/volctl/app.py
@@ -11,7 +11,7 @@ from volctl.pulseaudio import PulseAudioManager
 from volctl.prefs import PreferencesDialog
 from volctl.slider_win import VolumeSliders
 
-DEFAULT_MIXER_CMD = '/usr/bin/pavucontrol'
+DEFAULT_MIXER_CMD = 'pavucontrol'
 
 
 class VolctlApp():


### PR DESCRIPTION
Do not hard code the absolute path `/usr/bin/pavucontrol`, as pavucontrol binary is not always installed at `/usr` in every system. In particular [NixOS](https://nixos.org/) does not follow FHS.

It should be enough to let the system find pavucontrol in `$PATH`

See discussion at https://github.com/NixOS/nixpkgs/pull/75949