### PR TITLE
Correctly determine main sink

### DIFF
--- a/volctl/lib/pa_wrapper.py
+++ b/volctl/lib/pa_wrapper.py
@@ -17,6 +17,7 @@ from volctl.lib.pulseaudio import (
     pa_context_notify_cb_t,
     pa_context_subscribe_cb_t,
     pa_client_info_cb_t,
+    pa_server_info_cb_t,
     pa_sink_input_info_cb_t,
     pa_context_success_cb_t,
     pa_stream_request_cb_t,
@@ -38,6 +39,7 @@ from volctl.lib.pulseaudio import (
     pa_context_get_sink_info_list,
     pa_context_get_sink_input_info_list,
     pa_context_get_client_info,
+    pa_context_get_server_info,
     pa_context_get_sink_info_by_index,
     pa_context_get_sink_input_info,
     pa_context_set_sink_volume_by_index,
@@ -101,6 +103,7 @@ class PulseAudio:
         remove_sink_cb,
         new_sink_input_cb,
         remove_sink_input_cb,
+        default_sink_cb,
     ):
         # pylint: disable=too-many-arguments
 
@@ -110,6 +113,7 @@ class PulseAudio:
         self.remove_client_cb = remove_client_cb
         self.new_sink_cb = new_sink_cb
         self.remove_sink_cb = remove_sink_cb
+        self.default_sink_cb = default_sink_cb
 
         self.pa_mainloop = pa_threaded_mainloop_new()
         self.pa_mainloop_api = pa_threaded_mainloop_get_api(self.pa_mainloop)
@@ -129,6 +133,7 @@ class PulseAudio:
             self._pa_sink_input_info_cb
         )
         self.__pa_client_info_list_cb = pa_client_info_cb_t(self._pa_client_info_cb)
+        self.__pa_server_info_cb = pa_server_info_cb_t(self._pa_server_info_cb)
 
         pa_threaded_mainloop_start(self.pa_mainloop)
 
@@ -209,6 +214,11 @@ class PulseAudio:
         )
         pa_operation_unref(operation)
 
+        operation = pa_context_get_server_info(
+            self.context, self.__pa_server_info_cb, None
+        )
+        pa_operation_unref(operation)
+
     def _pa_context_subscribe_cb(self, context, event_type, index, user_data):
         efac = event_type & PA_SUBSCRIPTION_EVENT_FACILITY_MASK
         etype = event_type & PA_SUBSCRIPTION_EVENT_TYPE_MASK
@@ -263,6 +273,10 @@ class PulseAudio:
                 self._dict_from_proplist(struct.contents.proplist),
             )
 
+    def _pa_server_info_cb(self, context, struct, data):
+        if struct:
+            self.default_sink_cb(struct.contents.default_sink_name)
+
     @staticmethod
     def _null_cb(param_a=None, param_b=None, param_c=None, param_d=None):
         return
@@ -289,6 +303,8 @@ class PulseAudioManager:
         self.volctl = volctl
         self._pa_clients = {}
         self._pa_sinks = {}
+        self._pa_sinks_by_name = {}
+        self._default_sink = None
         self._pa_sink_inputs = {}
         self._pulseaudio = PulseAudio(
             self._on_new_pa_client,
@@ -297,6 +313,7 @@ class PulseAudioManager:
             self._on_remove_pa_sink,
             self._on_new_pa_sink_input,
             self._on_remove_pa_sink_input,
+            self._on_default_sink,
         )
         self.context = self._pulseaudio.context
         self.samplespec = pa_sample_spec()
@@ -335,8 +352,14 @@ class PulseAudioManager:
             first_key = list(self._pa_sinks.keys())[0]
             return self._pa_sinks[first_key]
         except IndexError:
-            pass
-        return None
+            return None
+
+    def get_main_sink(self):
+        """Returns sink for master volume"""
+        if self._default_sink is None:
+            return self.get_first_sink()
+
+        return self._pa_sinks_by_name[self._default_sink]
 
     def set_sink_volume(self, index, cvolume):
         """Set sink volume by index."""
@@ -358,11 +381,11 @@ class PulseAudioManager:
 
     def set_main_volume(self, volume):
         """Set main volume"""
-        self.get_first_sink().set_volume(volume)
+        self.get_main_sink().set_volume(volume)
 
     def toggle_main_mute(self):
         """Toggle main mute"""
-        sink = self.get_first_sink()
+        sink = self.get_main_sink()
         sink.set_mute(not sink.mute)
 
     # callbacks called by pulseaudio
@@ -378,13 +401,26 @@ class PulseAudioManager:
 
     def _on_new_pa_sink(self, index, struct, props):
         if index not in self._pa_sinks:
-            self._pa_sinks[index] = Sink(self, index, struct, props)
+            sink = Sink(self, index, struct, props)
+            self._pa_sinks[index] = sink
+            self._pa_sinks_by_name[sink.sink_name] = sink
             GObject.idle_add(self.volctl.slider_count_changed)
         else:
-            self._pa_sinks[index].update(struct, props)
+            sink = self._pa_sinks[index]
+
+            old_name = sink.sink_name
+            new_name = struct.name
+            if old_name != new_name:
+                # need to update the dict before calling update(), because that again relies
+                # on get_main_sink()
+                del self._pa_sinks_by_name[old_name]
+                self._pa_sinks_by_name[new_name] = sink
+
+            sink.update(struct, props)
 
     def _on_remove_pa_sink(self, index):
-        del self._pa_sinks[index]
+        sink = self._pa_sinks.pop(index)
+        del self._pa_sink_index_by_name[sink.sink_name]
         GObject.idle_add(self.volctl.slider_count_changed)
 
     def _on_new_pa_sink_input(self, index, struct, props):
@@ -407,6 +443,8 @@ class PulseAudioManager:
             del self._pa_sink_inputs[index]
             GObject.idle_add(self.volctl.slider_count_changed)
 
+    def _on_default_sink(self, name):
+        self._default_sink = name
 
 class AbstractMonitorableSink:
     """Base class for Sinks."""
@@ -491,13 +529,14 @@ class Sink(AbstractMonitorableSink):
         super().update(struct, props)
         # set values
         self._name = struct.description.decode("utf-8")
+        self._sink_name = struct.name
         self._icon_name = "audio-card"
         self.volume = struct.volume.values[0]
         self.channels = struct.volume.channels
         self.mute = bool(struct.mute)
 
         # notify volctl about update (first sound card)
-        if self == self.pa_mgr.get_first_sink():
+        if self == self.pa_mgr.get_main_sink():
             GObject.idle_add(self.pa_mgr.volctl.update_values, self.volume, self.mute)
         # scale update
         GObject.idle_add(
@@ -515,6 +554,10 @@ class Sink(AbstractMonitorableSink):
         self.mute = mute
         self.pa_mgr.set_sink_mute(self.idx, mute and 1 or 0)
 
+    @property
+    def sink_name(self):
+        """The PA-internal name of the sink"""
+        return self._sink_name
 
 class SinkInput(AbstractMonitorableSink):
     """An audio stream coming from a client."""


### PR DESCRIPTION
Currently, the sink with the lowest index is used as the main sink. This fails when multiple sinks exist, as there is no correlation between index number and default.

Hence, query PA for the default sink and return this where applicable.