### PR TITLE
update preferences window

### DIFF
--- a/volctl/prefs.py
+++ b/volctl/prefs.py
@@ -35,21 +35,21 @@ class PreferencesDialog(Gtk.Dialog):
         self.listbox.add(row)
 
         self._add_switch("show-percentage")
+        self._add_switch("vu-enabled")
+        self._add_scale("mouse-wheel-step", self._scale_mouse_wheel_step_format, False)
         self._add_switch("auto-close")
-        self._row_timeout = self._add_scale("timeout", self._scale_timeout_format)
-        self._add_scale("mouse-wheel-step", self._scale_mouse_wheel_step_format)
+        self._row_timeout = self._add_scale("timeout", self._scale_timeout_format, True)
         self._add_switch("osd-enabled")
         self._row_osd_timeout = self._add_scale(
-            "osd-timeout", self._scale_timeout_format
+            "osd-timeout", self._scale_timeout_format, True
         )
-        self._row_osd_size = self._add_scale("osd-scale", self._scale_osd_size_format)
-        self._add_switch("vu-enabled")
+        self._row_osd_size = self._add_scale("osd-scale", self._scale_osd_size_format, True)
         self._add_entry("mixer-command", self._default_mixer_cmd)
         self._add_switch("prefer-gtksi")
 
+        self.show_all()
         self._update_rows()
         self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
-        self.show_all()
 
     def _add_switch(self, name):
         key = self._schema.get_key(name)
@@ -70,7 +70,7 @@ class PreferencesDialog(Gtk.Dialog):
 
         self.listbox.add(row)
 
-    def _add_scale(self, name, format_func):
+    def _add_scale(self, name, format_func, indent):
         key = self._schema.get_key(name)
         row = Gtk.ListBoxRow()
         row.set_tooltip_text(key.get_description())
@@ -78,10 +78,13 @@ class PreferencesDialog(Gtk.Dialog):
         hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         row.add(hbox)
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        hbox.pack_start(vbox, True, True, 10)
+        if indent:
+            hbox.pack_start(vbox, True, True, 30)
+        else:
+            hbox.pack_start(vbox, True, True, 10)
 
-        label = Gtk.Label("  " + key.get_summary(), xalign=0)
-        vbox.pack_start(label, True, True, 0)
+        label = Gtk.Label(key.get_summary(), xalign=0)
+        vbox.pack_start(label, True, True, 10)
         scale = Gtk.Scale().new(Gtk.Orientation.HORIZONTAL)
         key_range = key.get_range()
         scale.set_range(key_range[1][0], key_range[1][1])
@@ -131,15 +134,15 @@ class PreferencesDialog(Gtk.Dialog):
 
     def _update_rows(self):
         if self._settings.get_boolean("auto-close"):
-            self._row_timeout.show()
+            self._row_timeout.set_sensitive(True)
         else:
-            self._row_timeout.hide()
+            self._row_timeout.set_sensitive(False)
         if self._settings.get_boolean("osd-enabled"):
-            self._row_osd_timeout.show()
-            self._row_osd_size.show()
+            self._row_osd_timeout.set_sensitive(True)
+            self._row_osd_size.set_sensitive(True)
         else:
-            self._row_osd_timeout.hide()
-            self._row_osd_size.hide()
+            self._row_osd_timeout.set_sensitive(False)
+            self._row_osd_size.set_sensitive(False)
 
     # GSettings callback
 


### PR DESCRIPTION
 - **initialize** row items **correctly** on startup (`_update_rows()` after `show_all()`)
 - scales **sensitive/insensitive** instead of show/hide
 - **fix indentation** of scales
 - increase vertical space
 - change order

Before:

![Screenshot at 2021-08-23 00-46-04](https://user-images.githubusercontent.com/49864414/130372421-fd7f73f7-ac11-4dee-be06-02c6f9e55228.png)

After:

![Screenshot at 2021-08-23 00-46-37](https://user-images.githubusercontent.com/49864414/130372431-47013a74-33fb-44b1-b99b-2e0db89b8a17.png)

