### PR TITLE
fix crazy window movement on resize action

### DIFF
--- a/volctl/prefs.py
+++ b/volctl/prefs.py
@@ -48,7 +48,7 @@ class PreferencesDialog(Gtk.Dialog):
         self._add_switch("prefer-gtksi")
 
         self._update_rows()
-        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        self.set_position(Gtk.WindowPosition.CENTER)
         self.show_all()
 
     def _add_switch(self, name):


### PR DESCRIPTION
On up-to-date Manjaro MATE.

Before:

![before](https://user-images.githubusercontent.com/49864414/130372340-1de16fe6-b9ae-449d-9303-b15cb11bcf1f.gif)

After:

![after](https://user-images.githubusercontent.com/49864414/130372348-8531adcb-aff2-4422-b88b-b572701017f2.gif)
