### PR TITLE
Add preference to allow going past 100% volume

### DIFF
--- a/data/apps.volctl.gschema.xml
+++ b/data/apps.volctl.gschema.xml
@@ -50,6 +50,11 @@
       <summary>Auto-close timeout</summary>
       <description>Time after the pop-up closes automatically.</description>
     </key>
+    <key type="b" name="allow-extra-volume">
+      <default>false</default>
+      <summary>Allow extra volume</summary>
+      <description>Enable increasing volume beyond 100%.</description>
+    </key>
     <!-- OSD -->
     <key type="b" name="osd-enabled">
       <default>true</default>

--- a/volctl/prefs.py
+++ b/volctl/prefs.py
@@ -54,6 +54,7 @@ class PreferencesDialog(Gtk.Dialog):
 
         # Volume slider window options
         self._create_section_label("Volume sliders")
+        self._add_switch("allow-extra-volume")
         self._add_switch("show-percentage")
         self._add_switch("vu-enabled")
         self._add_switch("auto-close")

--- a/volctl/slider_win.py
+++ b/volctl/slider_win.py
@@ -188,9 +188,20 @@ class VolumeSliders(Gtk.Window):
         name, icon_name, val, mute = props
         # Scale
         scale = Gtk.Scale().new(Gtk.Orientation.VERTICAL)
-        scale.set_range(0.0, 1.0)
+
+        scale_size = 128
+        volume_lim = 1.0
+        # TODO: this should come from _volctl and should be
+        # configurable.
+        extra_volume_factor = 1.5
+        if self._volctl.settings.get_boolean("allow-extra-volume"):
+            scale_size = int(scale_size * extra_volume_factor)
+            volume_lim = extra_volume_factor
+            scale.add_mark(1.0, Gtk.PositionType.LEFT, None)
+
+        scale.set_range(0.0, volume_lim)
         scale.set_inverted(True)
-        scale.set_size_request(24, 128)
+        scale.set_size_request(24, scale_size)
         scale.set_margin_top(self.SPACING)
         scale.set_tooltip_markup(name)
         self._set_increments_on_scale(scale)


### PR DESCRIPTION
This is something PulseAudio allows, but before this patch, you needed to open the mixer to make use of this feature.

This commit adds a preference which toggles increasing volume beyond 100%, which when turned on, modifies the Gtk.Scale widgets to go up to 150, with a marker indicating where 100% is.

When enabled, this is how it looks like:

![2022-10-07_22-39](https://user-images.githubusercontent.com/9742985/194643946-22e952d0-9c3c-43af-ad0d-486302d62fb1.png)

As the todo comment in the patch indicates, IIRC it's possible to even go beyond 150% volume, so it might make sense to make that number configurable also, but that'd rarely be used I suppose.