### PR TITLE
Allow setting mouse-wheel step to 1.

### DIFF
--- a/data/apps.volctl.gschema.xml
+++ b/data/apps.volctl.gschema.xml
@@ -13,7 +13,7 @@
   <schema id="apps.volctl" gettext-domain="volctl">
     <!-- Tray icon -->
     <key type="i" name="mouse-wheel-step">
-      <range min="3" max="50"/>
+      <range min="1" max="50"/>
       <default>15</default>
       <summary>Mouse wheel step</summary>
       <description>The sensitivity of mouse wheel volume changes.</description>


### PR DESCRIPTION
Currently, the minimum value for the mouse-wheel step is equal to 3.
It'd be nice for the user to be able to set it to a lower value (minimum 1).